### PR TITLE
refactor(DL-16084): Addressed PlatOps comments

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.9.4
+version = 3.9.6
 runner.dialect = scala213
 
 maxColumn = 120

--- a/app/uk/gov/hmrc/entrydeclarationintervention/controllers/api/DocumentationController.scala
+++ b/app/uk/gov/hmrc/entrydeclarationintervention/controllers/api/DocumentationController.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.entrydeclarationintervention.controllers
+package uk.gov.hmrc.entrydeclarationintervention.controllers.api
 
 import controllers.Assets
 import play.api.libs.json.Json

--- a/conf/api.routes
+++ b/conf/api.routes
@@ -1,4 +1,4 @@
 # microservice specific routes
 
-GET         /api/definition                                        uk.gov.hmrc.entrydeclarationintervention.controllers.DocumentationController.definition()
-GET         /api/conf/:version/*file                               uk.gov.hmrc.entrydeclarationintervention.controllers.DocumentationController.conf(version: String, file: String)
+GET         /api/definition                                        uk.gov.hmrc.entrydeclarationintervention.controllers.api.DocumentationController.definition()
+GET         /api/conf/:version/*file                               uk.gov.hmrc.entrydeclarationintervention.controllers.api.DocumentationController.conf(version: String, file: String)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -29,7 +29,7 @@ object AppDependencies {
   val test: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"            %% "bootstrap-test-play-30" % bootstrapVersion,
     "org.scalatestplus.play" %% "scalatestplus-play"     % "7.0.1",
-    "org.scalamock"          %% "scalamock"              % "7.3.0",
+    "org.scalamock"          %% "scalamock"              % "7.3.2",
     "org.scalatestplus"      %% "scalacheck-1-18"        % "3.2.19.0"
   ).map(_ % Test)
 

--- a/test/uk/gov/hmrc/entrydeclarationintervention/controllers/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationintervention/controllers/DocumentationControllerSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 HM Revenue & Customs
+ * Copyright 2025 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers, Injecting}
 import play.api.{Application, Environment, Mode}
 import uk.gov.hmrc.entrydeclarationintervention.config.MockAppConfig
+import uk.gov.hmrc.entrydeclarationintervention.controllers.api.DocumentationController
 
 class DocumentationControllerSpec extends AnyWordSpecLike with Matchers with OptionValues with MockAppConfig with Injecting with GuiceOneAppPerSuite {
   override lazy val app: Application = new GuiceApplicationBuilder()

--- a/test/uk/gov/hmrc/entrydeclarationintervention/controllers/api/DocumentationControllerSpec.scala
+++ b/test/uk/gov/hmrc/entrydeclarationintervention/controllers/api/DocumentationControllerSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.entrydeclarationintervention.controllers
+package uk.gov.hmrc.entrydeclarationintervention.controllers.api
 
 import controllers.Assets
 import org.scalamock.matchers.Matchers
@@ -29,7 +29,6 @@ import play.api.test.Helpers._
 import play.api.test.{FakeRequest, Helpers, Injecting}
 import play.api.{Application, Environment, Mode}
 import uk.gov.hmrc.entrydeclarationintervention.config.MockAppConfig
-import uk.gov.hmrc.entrydeclarationintervention.controllers.api.DocumentationController
 
 class DocumentationControllerSpec extends AnyWordSpecLike with Matchers with OptionValues with MockAppConfig with Injecting with GuiceOneAppPerSuite {
   override lazy val app: Application = new GuiceApplicationBuilder()


### PR DESCRIPTION
Addressed the previous PlatOps comment which looked like

> You have multiple routes files conf/api.routes, conf/app.routes using the same package uk.gov.hmrc.entrydeclarationintervention.controllers, which leads to collision with the reverse routes. Please ensure each routes file refers to a different package.